### PR TITLE
Add prettier on .vscode file save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
Adds a config option for VSCode to run the prettier linter on file save.